### PR TITLE
Addressing to maven build issues

### DIFF
--- a/JCache-Examples/pom.xml
+++ b/JCache-Examples/pom.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/Java-EE/team-info/pom.xml
+++ b/Java-EE/team-info/pom.xml
@@ -2,7 +2,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>payara-examples-parent</artifactId>
+    <artifactId>Java-EE</artifactId>
     <groupId>fish.payara.examples</groupId>
     <version>1.0-SNAPSHOT</version>
   </parent>


### PR DESCRIPTION
When I built team-info project, it failed with the following error:

 [FATAL] Non-resolvable parent POM for fish.payara:team-info:1.0-SNAPSHOT: Could not find artifact fish.payara.examples:payara-examples-parent:pom:1.0-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 4, column 11

I also noticed a blank line at the heading of JCache-Examples/pom.xml. I am not unsure if it will cause any severe issue though.