### PR TITLE
Exclude JavaScript and CSS from github stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Marking files as vendor to exclded them from github statistics so that Java is shown is major language. See https://github.com/github/linguist#overrides
+
+*.js linguist-vendored
+*.css linguist-vendored


### PR DESCRIPTION
See that my fork now hows Java as the language of the repository: https://github.com/OndrejM?utf8=%E2%9C%93&tab=repositories&q=payara-examples&type=&language=

The main repository shows JavaScript as the main language because there are just too many copy&pasted JavaScript files which shouldn't be counted into statistics: https://github.com/payara?utf8=%E2%9C%93&q=payara-examples