### PR TITLE
[PAYARA-4237] - Add Zipkin wrapper example

### DIFF
--- a/ecosystem/zipkin-tracing-library-example/README.md
+++ b/ecosystem/zipkin-tracing-library-example/README.md
@@ -1,0 +1,18 @@
+# Zipkin Tracing Wrapper Library
+
+This is a project to demonstrate how one might set up a wrapper for Zipkin Tracer to use on Payara 5.194 and above as an alternative implementation of Opentracing.
+
+## Building
+
+Simply run `mvn clean install` to build this wrapper implementation.
+
+## Using with Payara Server
+
+Important: Deploying this project as an application DOES NOT WORK
+The resulting JAR file from building this example project should be added to Payara Server as a library
+
+Once the server is running, add the JAR as a library with the asadmin command `add-library zipkin-tracer-lib-1.0-jar-with-dependencies.jar` as per the server documentation.
+
+Tracing must be enabled with `set-requesttracing-configuration --enabled true --dynamic true`
+
+After executing these steps, navigate to the Zipkin UI at http://localhost:9411/ (as configured by default in the ZipkinTracerWrapper class) and you will be able to retrieve traces from Payara Server. If your Zipkin instance is configured to a different URL, simply change the URL in ZipkinTracerWrapper to match your destination and rebuild the project.

--- a/ecosystem/zipkin-tracing-library-example/README.md
+++ b/ecosystem/zipkin-tracing-library-example/README.md
@@ -8,7 +8,7 @@ Simply run `mvn clean install` to build this wrapper implementation.
 
 ## Using with Payara Server
 
-Important: Deploying this project as an application DOES NOT WORK
+IMPORTANT: Deploying this project as an application *DOES NOT WORK*
 The resulting JAR file from building this example project should be added to Payara Server as a library
 
 Once the server is running, add the JAR as a library with the asadmin command `add-library zipkin-tracer-lib-1.0-jar-with-dependencies.jar` as per the server documentation.

--- a/ecosystem/zipkin-tracing-library-example/pom.xml
+++ b/ecosystem/zipkin-tracing-library-example/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>fish.payara.ecosystem</groupId>
+    <artifactId>zipkin-tracer-lib</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.zipkin.brave</groupId>
+                <artifactId>brave-bom</artifactId>
+                <version>5.9.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    
+    <dependencies>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>2.0.SP1</version>
+            <scope>provided</scope>
+        </dependency> 
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.brave</groupId>
+            <artifactId>brave-opentracing</artifactId>
+            <version>0.31.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-util</artifactId>
+            <version>0.31.0</version>
+            <type>jar</type>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/io.zipkin.reporter2/zipkin-sender-okhttp3 -->
+        <dependency>
+            <groupId>io.zipkin.reporter2</groupId>
+            <artifactId>zipkin-sender-okhttp3</artifactId>
+            <version>2.8.4</version>
+        </dependency>
+
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>         
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+    
+</project>

--- a/ecosystem/zipkin-tracing-library-example/pom.xml
+++ b/ecosystem/zipkin-tracing-library-example/pom.xml
@@ -1,4 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>fish.payara.ecosystem</groupId>

--- a/ecosystem/zipkin-tracing-library-example/src/main/java/fish/payara/zipkin/tracer/lib/ZipkinTracerWrapper.java
+++ b/ecosystem/zipkin-tracing-library-example/src/main/java/fish/payara/zipkin/tracer/lib/ZipkinTracerWrapper.java
@@ -1,7 +1,40 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ *
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
  */
 package fish.payara.zipkin.tracer.lib;
 
@@ -10,7 +43,6 @@ import brave.opentracing.BraveTracer;
 import brave.propagation.B3Propagation;
 import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.ExtraFieldPropagation.Factory;
-import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;

--- a/ecosystem/zipkin-tracing-library-example/src/main/java/fish/payara/zipkin/tracer/lib/ZipkinTracerWrapper.java
+++ b/ecosystem/zipkin-tracing-library-example/src/main/java/fish/payara/zipkin/tracer/lib/ZipkinTracerWrapper.java
@@ -1,0 +1,88 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package fish.payara.zipkin.tracer.lib;
+
+import brave.Tracing;
+import brave.opentracing.BraveTracer;
+import brave.propagation.B3Propagation;
+import brave.propagation.ExtraFieldPropagation;
+import brave.propagation.ExtraFieldPropagation.Factory;
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.Format;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+import java.util.Arrays;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.okhttp3.OkHttpSender;
+
+/**
+ *
+ * A Wrapper for Zipkin Tracer to allow it to be loaded as a service in
+ * Payara Server
+ * 
+ * @author Cuba Stanley
+ */
+public class ZipkinTracerWrapper implements io.opentracing.Tracer {
+    
+    private static Tracer wrappedTracer;
+    
+    public ZipkinTracerWrapper() {
+        setUpTracer();
+    }
+    
+    private synchronized void setUpTracer() {
+        if(wrappedTracer == null) {
+            
+            OkHttpSender sender = OkHttpSender.create("http://localhost:9411/api/v2/spans");
+            AsyncReporter spanReporter = AsyncReporter.create(sender);
+            
+            Factory propagationFactory = ExtraFieldPropagation.newFactoryBuilder(B3Propagation.FACTORY)
+                                                              .addPrefixedFields("baggage-", Arrays.asList("country-code", "user-id"))
+                                                              .build();
+            
+            Tracing braveTracing = Tracing.newBuilder()
+                                          .localServiceName("zipkin-test")
+                                          .propagationFactory(propagationFactory)
+                                          .spanReporter(spanReporter)
+                                          .build();
+            try {
+                wrappedTracer = BraveTracer.create(braveTracing);
+                GlobalTracer.register(wrappedTracer);
+            } catch(Exception e) {
+                System.out.print("There was an error initialising: \n");
+                e.printStackTrace();
+            }
+        }
+    }  
+    
+    @Override
+    public ScopeManager scopeManager() {
+        return wrappedTracer.scopeManager();
+    }
+
+    @Override
+    public Span activeSpan() {
+        return wrappedTracer.activeSpan();
+    }
+
+    @Override
+    public SpanBuilder buildSpan(String string) {
+        return wrappedTracer.buildSpan(string);
+    }
+
+    @Override
+    public <C> void inject(SpanContext sc, Format<C> format, C c) {
+        wrappedTracer.inject(sc, format, c);
+    }
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C c) {
+        return wrappedTracer.extract(format, c);
+    }
+}

--- a/ecosystem/zipkin-tracing-library-example/src/main/resources/META-INF/services/io.opentracing.Tracer
+++ b/ecosystem/zipkin-tracing-library-example/src/main/resources/META-INF/services/io.opentracing.Tracer
@@ -1,0 +1,2 @@
+
+fish.payara.zipkin.tracer.lib.ZipkinTracerWrapper


### PR DESCRIPTION
## Overview ##
This PR adds a small example project to show how one might wrap Zipkin for use as an alternative OpenTracing implementation on Payara Server. The example is a result of testing Zipkin compatibility with Payara

IT IS IMPORTANT TO NOTE: From experimenting, versions of Zipkin using OpenTracing 0.32.0 or higher are NOT compatible with Payara Server

### Testing ###
If you'd like to test it out, just follow the steps in the README - you'll need to make sure Zipkin is running (easiest way is to run `docker run -d -p 9411:9411 openzipkin/zipkin`)