### PR TITLE
FISH-10828 - add arquillian example with junit5 for payara6

### DIFF
--- a/ecosystem/arquillian-junit5-example/README.md
+++ b/ecosystem/arquillian-junit5-example/README.md
@@ -1,0 +1,79 @@
+//
+// Copyright (c) 2025 Payara Foundation and/or its affiliates.
+//
+
+# Payara Embedded integration with Arquillian
+
+The example demonstrates how to create a test suite that runs the tests inside various Payara Platform distributions using Arquillian and the Payara Embedded Arquillian Container.
+
+You'll find the following in this project:
+
+* Arquillian set up in [pom.xml](pom.xml) using `arquillian-bom`
+* Arquillian set up in [pom.xml](pom.xml) for JUnit5 using `arquillian-junit5-container`
+* Profiles that configure Arquillian to run tests using various Payara Embedded containers in [pom.xml](pom.xml)
+* Arquillian container configuration set up using the [arquillian.xml](src/test/resources/arquillian.xml) file. The configuration for a particular Arquilian container in `arquillian.xml` 
+is enabled using `arquillian.launch` system property for the suirefire maven plugin in [pom.xml](pom.xml). 
+Each maven profile enables a Arquillian configuration.
+* The test case in [PersonDaoTest.java](src/test/java/fish/payara/examples/dao/PersonDaoTest.java) prepares 
+a deployment for Arquillian and executes the test inside one of the Payara Arquillian containers
+
+## Build and run the example
+
+This is a Maven project. You'll need Maven installed to build it.
+
+### Build all required projects
+
+Before running this project, you also need to build the required parent projects in this repository.
+
+Go to the root directory of this repository and execute
+
+```
+mvn --also-make --projects ecosystem/arquillian-example install
+``` 
+
+to build all required projects.
+
+Or simply execute the following to build all projects:
+
+```
+mvn install
+```
+
+
+### Run the default profile
+
+To build and run the example test using the default profile (that uses Payara Embedded):
+
+```
+mvn test
+```
+
+### Run tests using Payara Embedded
+
+```
+mvn -Ppayara-server-embedded test
+```
+
+
+### Run tests using a Payara Server installation (Managed)
+
+```
+mvn -Ppayara-server-managed test
+```
+
+Payara Server is automatically installed and started (Managed). The Maven Dependency plugin 
+is used to download and unpack Payara Server from Maven repository, Arquillian managed container 
+starts it before exusting the tests and then stops it.
+
+
+### Run tests on a running Payara Server (Remote)
+
+Start Payara Server on local computer and then run 
+
+```
+mvn -Ppayara-server-remote test
+```
+
+This configuration runs tests against the Payara Server that must be already running on localhost. 
+To run the tests on a remote Payara Server, adjust the payara-server-remote configuration in the 
+[arquillian.xml](src/test/resources/arquillian.xml) file.

--- a/ecosystem/arquillian-junit5-example/pom.xml
+++ b/ecosystem/arquillian-junit5-example/pom.xml
@@ -1,0 +1,239 @@
+<!--
+ Copyright (c) 2017-2022 Payara Foundation and/or its affiliates. All rights reserved.
+
+ The contents of this file are subject to the terms of either the GNU
+ General Public License Version 2 only ("GPL") or the Common Development
+ and Distribution License("CDDL") (collectively, the "License").  You
+ may not use this file except in compliance with the License.  You can
+ obtain a copy of the License at
+ https://github.com/payara/Payara/blob/master/LICENSE.txt
+ See the License for the specific
+ language governing permissions and limitations under the License.
+
+ When distributing the software, include this License Header Notice in each
+ file and include the License file at glassfish/legal/LICENSE.txt.
+
+ GPL Classpath Exception:
+ The Payara Foundation designates this particular file as subject to the "Classpath"
+ exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ file that accompanied this code.
+
+ Modifications:
+ If applicable, add the following below the License Header, with the fields
+ enclosed by brackets [] replaced by your own identifying information:
+ "Portions Copyright [year] [name of copyright owner]"
+
+ Contributor(s):
+ If you wish your version of this file to be governed by only the CDDL or
+ only the GPL Version 2, indicate your decision by adding "[Contributor]
+ elects to include this software in this distribution under the [CDDL or GPL
+ Version 2] license."  If you don't indicate a single choice of license, a
+ recipient has the option to distribute your version of this file under
+ either the CDDL, the GPL Version 2 or to extend the choice of license to
+ its licensees as provided above.  However, if you add GPL Version 2 code
+ and therefore, elected the GPL Version 2 license, then the option applies
+ only if the new code is made subject to such option by the copyright
+ holder.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <groupId>fish.payara.examples</groupId>
+    <artifactId>arquillian-junit5-example</artifactId>
+    <packaging>war</packaging>
+    
+    <name>Payara Arquillian with Junit5 example</name>
+    <description>Example of Arquillian integration with various Payara Platform runtimes using Junit5</description>
+    <parent>
+        <groupId>fish.payara.examples</groupId>
+        <artifactId>ecosystem</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>    
+    
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>1.9.4.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+  
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.12.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-core</artifactId>
+            <scope>test</scope>
+            <type>jar</type>
+        </dependency>
+        
+    </dependencies>
+
+    <build>
+        <finalName>arquillian-example</finalName>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>3.4.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.5.3</version>
+                    <configuration>
+                        <systemProperties>
+                            <arquillian.launch>${arquillian.qualifier}</arquillian.launch>
+                        </systemProperties>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+            </testResource>
+        </testResources>
+    </build>
+    
+    <profiles>
+        <profile>
+            <!--
+            This profile will download Payara server embedded distribution and start it 
+            from the Arquillian container in the same JVM.
+            -->
+            <id>payara-server-embedded</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <arquillian.qualifier>payara-server-embedded</arquillian.qualifier>
+                <skipUnitTests>false</skipUnitTests>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>arquillian-payara-server-embedded</artifactId>
+                    <version>3.1</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>fish.payara.extras</groupId>
+                    <artifactId>payara-embedded-all</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <!--
+            This profile will install Payara server and start up the server from 
+            the Arquillian container.
+            -->
+            <id>payara-server-managed</id>
+
+            <properties>
+                <arquillian.qualifier>payara-server-managed</arquillian.qualifier>
+                <payara.directory.name>payara6</payara.directory.name>
+                <payara.domain.name>domain1</payara.domain.name>
+            </properties>
+
+            <dependencies>
+
+                <!-- Payara Server distribution to download and install -->
+                <dependency>
+                    <groupId>fish.payara.distributions</groupId>
+                    <artifactId>payara</artifactId>
+                    <type>zip</type>
+                    <version>${payara.version}</version>
+                </dependency>
+
+                <!-- The actual Arquillian connector -->
+                <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>arquillian-payara-server-managed</artifactId>
+                    <version>3.1</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <markersDirectory>${project.build.directory}/dependency-maven-plugin-markers</markersDirectory>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>fish.payara.distributions</groupId>
+                                            <artifactId>payara</artifactId>
+                                            <type>zip</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <payara.home>${project.build.directory}/${payara.directory.name}</payara.home>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <!--
+            This profile will use a running Payara server.
+            -->
+            <id>payara-server-remote</id>
+
+            <properties>
+                <arquillian.qualifier>payara-server-remote</arquillian.qualifier>
+                <!--<skipUnitTests>true</skipUnitTests>-->
+            </properties>
+
+            <dependencies>
+
+                <!-- The actual Arquillian connector -->
+                <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>arquillian-payara-server-remote</artifactId>
+                    <version>3.1</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+
+        </profile>
+    </profiles>
+    
+</project>

--- a/ecosystem/arquillian-junit5-example/src/main/java/fish/payara/examples/dao/PersonDao.java
+++ b/ecosystem/arquillian-junit5-example/src/main/java/fish/payara/examples/dao/PersonDao.java
@@ -1,0 +1,39 @@
+/**
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates.
+ * All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ */
+package fish.payara.examples.dao;
+
+import fish.payara.examples.domain.Person;
+
+import jakarta.ejb.Stateless;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+
+/**
+ * Created by mertcaliskan
+ */
+@Stateless
+public class PersonDao {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public List<Person> getAll() {
+        return entityManager.createNamedQuery("Person.getAll", Person.class).getResultList();
+    }
+}

--- a/ecosystem/arquillian-junit5-example/src/main/java/fish/payara/examples/domain/Person.java
+++ b/ecosystem/arquillian-junit5-example/src/main/java/fish/payara/examples/domain/Person.java
@@ -1,0 +1,68 @@
+/**
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates.
+ * All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ */
+package fish.payara.examples.domain;
+
+import jakarta.persistence.*;
+
+/**
+ * Created by mertcaliskan
+ */
+@Entity
+@NamedQueries(
+        @NamedQuery(name = "Person.getAll", query = "select p from Person p")
+)
+public class Person {
+
+    @Id
+    @GeneratedValue
+    private long id;
+    private String name;
+    private String lastName;
+
+    public Person() {
+    }
+
+    public Person(String name, String lastName) {
+        this.name = name;
+        this.lastName = lastName;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+}

--- a/ecosystem/arquillian-junit5-example/src/test/java/fish/payara/examples/dao/PersonDaoJ5Test.java
+++ b/ecosystem/arquillian-junit5-example/src/test/java/fish/payara/examples/dao/PersonDaoJ5Test.java
@@ -1,0 +1,106 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.examples.dao;
+
+import fish.payara.examples.domain.Person;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import jakarta.ejb.EJB;
+import java.util.List;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * author: simonladen
+ */
+@ExtendWith(ArquillianExtension.class)
+public class PersonDaoJ5Test {
+
+    @EJB
+    private PersonDao personDao;
+    
+    @Inject TestData testData;
+    
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "arquillian-junit5-example.war")
+                .addClass(Person.class)
+                .addClass(PersonDao.class)
+                .addAsResource("test-persistence.xml", "META-INF/persistence.xml");
+    }
+
+    @BeforeEach
+    public void prepareTestData() {
+        testData.prepareForShouldReturnAllPerson();
+    }
+
+    @Test
+    public void shouldReturnAllPerson() throws Exception {
+        List<Person> personList = personDao.getAll();
+
+        assertNotNull(personList);
+        assertEquals(personList.size(), 1);
+        assertEquals(personList.get(0).getName(), "John");
+        assertEquals(personList.get(0).getLastName(), "Malkovich");
+    }
+
+    @Dependent
+    public static class TestData {
+
+        @PersistenceContext
+        private EntityManager entityManager;
+
+        @Transactional
+        public void prepareForShouldReturnAllPerson() {
+            entityManager.persist(new Person("John", "Malkovich"));
+        }
+    }
+}

--- a/ecosystem/arquillian-junit5-example/src/test/resources/arquillian.xml
+++ b/ecosystem/arquillian-junit5-example/src/test/resources/arquillian.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright (c) 2016-2025 Payara Foundation and/or its affiliates.
+All rights reserved.
+
+The contents of this file are subject to the terms of the Common Development
+and Distribution License("CDDL") (collectively, the "License").  You
+may not use this file except in compliance with the License.  You can
+obtain a copy of the License at
+https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+or packager/legal/LICENSE.txt.  See the License for the specific
+language governing permissions and limitations under the License.
+
+When distributing the software, include this License Header Notice in each
+file and include the License file at packager/legal/LICENSE.txt.
+-->
+<arquillian xmlns="http://jboss.org/schema/arquillian"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian
+            http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <engine>
+        <property name="deploymentExportPath">target/arquillian-deployments</property>
+    </engine>
+  
+    <defaultProtocol type="Servlet 5.0"/>
+    <container qualifier="payara-server-embedded" default="true">
+        <configuration>
+            <property name="bindHttpPort">7070</property>
+        </configuration>
+    </container>
+    <container qualifier="payara-server-managed">
+        <configuration>
+            <property name="adminPort">4848</property>
+        </configuration>
+    </container>
+    <container qualifier="payara-server-remote">
+        <configuration>
+            <property name="adminPort">4848</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/ecosystem/arquillian-junit5-example/src/test/resources/test-persistence.xml
+++ b/ecosystem/arquillian-junit5-example/src/test/resources/test-persistence.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+ Copyright (c) 2025 Payara Foundation and/or its affiliates.
+ All rights reserved.
+
+ The contents of this file are subject to the terms of the Common Development
+ and Distribution License("CDDL") (collectively, the "License").  You
+ may not use this file except in compliance with the License.  You can
+ obtain a copy of the License at
+ https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ or packager/legal/LICENSE.txt.  See the License for the specific
+ language governing permissions and limitations under the License.
+
+ When distributing the software, include this License Header Notice in each
+ file and include the License file at packager/legal/LICENSE.txt.
+ -->
+<persistence version="3.0" xmlns="https://jakarta.ee/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence              https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd">
+  <persistence-unit name="payaraEmbedded" transaction-type="JTA">
+    <properties>
+      <property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create"/>
+    </properties>
+  </persistence-unit>
+</persistence>

--- a/ecosystem/pom.xml
+++ b/ecosystem/pom.xml
@@ -53,6 +53,7 @@
     </parent>
    
     <modules>
+        <module>arquillian-junit5-example</module>
         <module>payara-maven</module>
         <module>maven-plugin-with-start-class</module>
         <module>maven-plugin-base-example</module>


### PR DESCRIPTION
Similar to https://github.com/payara/Payara-Examples/pull/205, but for Payara 6.
Jakarta dependencies are updated. It works with Payara 6.2022.1 by default.
Note: arquillian-example does not exist for Payara6. So this PR only adds the arquillian example with junit5, not the one with junit4.